### PR TITLE
🚧 [WIP] Refactoring for not using relative paths

### DIFF
--- a/components/atoms/Button/index.tsx
+++ b/components/atoms/Button/index.tsx
@@ -1,6 +1,4 @@
-import BaseButton from "./BaseButton";
-import GoogleButton from "./GoogleButton";
-import ChoiceButton from "./ChoiceButton";
-import YesNoButton from "./YesNoButton";
-
-export { BaseButton, GoogleButton, ChoiceButton, YesNoButton };
+export { default as BaseButton } from "./BaseButton";
+export { default as GoogleButton } from "./GoogleButton";
+export { default as ChoiceButton } from "./ChoiceButton";
+export { default as YesNoButton } from "./YesNoButton";

--- a/components/atoms/Icon/index.tsx
+++ b/components/atoms/Icon/index.tsx
@@ -1,27 +1,12 @@
-import GoogleIcon from "./GoogleIcon";
-import ArrowRightIcon from "./ArrowRightIcon";
-import ArrowLeftIcon from "./ArrowLeftIcon";
-import AlertFilledIcon from "./AlertFilledIcon";
-import MenuIcon from "./MenuIcon";
-import CheckIcon from "./CheckIcon";
-import CheckFilledIcon from "./CheckFilledIcon";
-import Satisfaction1FilledIcon from "./Satisfaction1FilledIcon";
-import Satisfaction2FilledIcon from "./Satisfaction2FilledIcon";
-import Satisfaction3FilledIcon from "./Satisfaction3FilledIcon";
-import Satisfaction4FilledIcon from "./Satisfaction4FilledIcon";
-import Satisfaction5FilledIcon from "./Satisfaction5FilledIcon";
-
-export {
-	GoogleIcon,
-	ArrowRightIcon,
-	ArrowLeftIcon,
-	AlertFilledIcon,
-	MenuIcon,
-	CheckIcon,
-	CheckFilledIcon,
-	Satisfaction1FilledIcon,
-	Satisfaction2FilledIcon,
-	Satisfaction3FilledIcon,
-	Satisfaction4FilledIcon,
-	Satisfaction5FilledIcon
-};
+export { default as GoogleIcon } from "./GoogleIcon";
+export { default as ArrowRightIcon } from "./ArrowRightIcon";
+export { default as ArrowLeftIcon } from "./ArrowLeftIcon";
+export { default as AlertFilledIcon } from "./AlertFilledIcon";
+export { default as MenuIcon } from "./MenuIcon";
+export { default as CheckIcon } from "./CheckIcon";
+export { default as CheckFilledIcon } from "./CheckFilledIcon";
+export { default as Satisfaction1FilledIcon } from "./Satisfaction1FilledIcon";
+export { default as Satisfaction2FilledIcon } from "./Satisfaction2FilledIcon";
+export { default as Satisfaction3FilledIcon } from "./Satisfaction3FilledIcon";
+export { default as Satisfaction4FilledIcon } from "./Satisfaction4FilledIcon";
+export { default as Satisfaction5FilledIcon } from "./Satisfaction5FilledIcon";

--- a/components/atoms/index.tsx
+++ b/components/atoms/index.tsx
@@ -1,0 +1,4 @@
+export * from "./Button";
+export * from "./Icon"
+export { default as BaseInput } from "./Input/BaseInput";
+export { default as CollectaLogo } from "./CollectaLogo";

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -1,0 +1,2 @@
+export * from "./atoms";
+export * from "./organisms";

--- a/components/organisms/SurveyFlow/index.tsx
+++ b/components/organisms/SurveyFlow/index.tsx
@@ -1,5 +1,3 @@
-import SurveyBegin from "./SurveyBegin";
-import SurveyQuestion from "./SurveyQuestion";
-import SurveyEnd from "./SurveyEnd";
-
-export { SurveyBegin, SurveyQuestion, SurveyEnd }
+export { default as SurveyBegin } from "./SurveyBegin";
+export { default as SurveyQuestion } from "./SurveyQuestion";
+export { default as SurveyEnd } from "./SurveyEnd";

--- a/components/organisms/index.tsx
+++ b/components/organisms/index.tsx
@@ -1,0 +1,3 @@
+export * from "./SurveyFlow";
+export { default as Question } from "./Question";
+export { default as QuestionInput } from "./QuestionInput";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -195,7 +195,6 @@ const HomeUserData: FC<UserData> = (props: UserData) => {
         console.log("ERROR....");
     }
 
-
     return (
         <div>
             <Head>

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -2,12 +2,15 @@ import React, { FC, useState } from "react";
 import Head from "next/head";
 import { styled } from "linaria/react";
 import { css } from "linaria";
-import { GoogleButton, BaseButton } from "../../components/atoms/Button";
-import CollectaLogo from "../../components/atoms/CollectaLogo";
 import { motion } from "framer-motion";
 import { useTheme } from "../../general/theming";
-import { BaseInput } from "../../components/atoms/Input";
-import { ArrowRightIcon } from "../../components/atoms/Icon";
+import {
+  BaseInput,
+  CollectaLogo,
+  GoogleButton,
+  BaseButton,
+  ArrowRightIcon
+} from "components";
 
 interface LoginProps {
   color?: string;
@@ -149,6 +152,7 @@ const Login: FC<LoginProps> = props => {
               animate={{ opacity: 1 }}
               transition={{ delay: 1.3, stiffness: 8, duration: 0.7 }}
             >
+
               <BaseInput
                 textAlign={"center"}
                 placeholder={"Escribe tu código aquí"}

--- a/pages/s/[id].tsx
+++ b/pages/s/[id].tsx
@@ -6,8 +6,6 @@ import { motion } from "framer-motion";
 import { styled } from "linaria/react";
 import { css } from "linaria";
 import { useTheme } from "../../general/theming";
-import { BaseButton } from "../../components/atoms/Button";
-import { ArrowRightIcon, ArrowLeftIcon } from "../../components/atoms/Icon";
 import {
 	querySurvey,
 	queryLastQuestionOfSurvey,
@@ -16,6 +14,7 @@ import {
 } from "../../general/queries";
 import { answerQuestion } from "../../general/mutations";
 import { SurveyBegin, SurveyQuestion } from "../../components/organisms/SurveyFlow";
+import { BaseButton, ArrowRightIcon, ArrowLeftIcon } from "components";
 import Head from "next/head";
 
 const Layout = styled.div`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,11 @@
         "moduleResolution": "node",
         "resolveJsonModule": true,
         "isolatedModules": true,
-        "jsx": "preserve"
+        "jsx": "preserve",
+        "baseUrl": ".",
+        "paths": {
+            "components": ["./components"]
+        }
     },
     "exclude": ["node_modules"],
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "next.config.js"]


### PR DESCRIPTION
This pull request is to stop using relative paths

**Before:**
```js
import { BaseButton } from "../../components/atoms/Button";
```

**After**
```js
import { BaseButton } from "components";
```